### PR TITLE
imports for testing

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,7 +22,7 @@ copyright = '2022, Michael Busuttil, Travis Valdez'
 author = 'Michael Busuttil, Travis Valdez'
 
 # The full version, including alpha/beta/rc tags
-release = '1.3.1'
+release = '1.3.2'
 
 # -- General configuration ---------------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name = 'sigfig',
     description = 'Python library for rounding numbers (with expected results)',
 
-    version = '1.3.1',
+    version = '1.3.2',
     license = 'MIT',
     url = 'https://sigfig.readthedocs.io/',
     install_requires =['SortedContainers'],

--- a/test/test.py
+++ b/test/test.py
@@ -14,7 +14,7 @@ import unittest, csv
 from numpy import float64, float32, int64, int32
 
 from sys import path
-path.append('../sigfig')
+path.insert(0, '../sigfig')
 from sigfig import round, _num_parse, roundit, round_unc, round_sf
 
 def function_parse(func):


### PR DESCRIPTION
Hi,

I tried to run the tests locally, but it fails (at least in python 3.8) if the package is already installed. The methods starting with _ are not available when importing the pip-installed package.
The change ensures that the current version of the repo is used instead of the installed package. Then also methods starting with _ can be imported.

Cheers,
Tim